### PR TITLE
Nivel de acceso para certificadores

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -43,7 +43,7 @@ define('FOPEN_READ_WRITE_CREATE_STRICT',		'x+b');
 */
 
 define('ACCLEVEL_USER',0);
-define('ACCLEVEL_MODERATOR',1);
+define('ACCLEVEL_MODERATOR',2);
 define('ACCLEVEL_ADMIN',10);
 define('ACCLEVEL_SUPERADMIN',20);
 


### PR DESCRIPTION
Modificado el acclevel, para evitar que los certificadores que se agreguen después de implementar esto https://github.com/ImperiumSAMP/MalosAiresRolePlay/commit/78d4a497cbae32973663b9054e48a394c3ac9c2a, no tengan acceso al panel.
